### PR TITLE
Fix isPrivate() to handle locally administered multicast addresses

### DIFF
--- a/src/Mac.php
+++ b/src/Mac.php
@@ -11,6 +11,8 @@ final class Mac
 ----------------------------------------------------------------------------- */
 
     /**
+     * Format MAC address.
+     *
      * @param string $mac Original MAC address.
      * @return string Colon formatted MAC address. Returns original MAC if
      * it is not valid. MAC should be checked for invalid first.
@@ -30,6 +32,8 @@ final class Mac
 ----------------------------------------------------------------------------- */
 
     /**
+     * Check if a MAC address is private.
+     *
      * @param string $mac Original MAC address.
      * @return bool If MAC address is private.
      */
@@ -37,10 +41,11 @@ final class Mac
     {
         $mac = self::clean( mac: $mac );
         if( strlen( $mac ) < 2 ) { return false; }
-        $char = $mac[1];
 
-        return in_array( needle: $char, haystack: ['2', '6', 'A', 'E'] );
+        return ( hexdec( $mac[1] ) & 0x2 ) === 0x2;
     }
+
+
 
 
 
@@ -48,6 +53,8 @@ final class Mac
 ----------------------------------------------------------------------------- */
 
     /**
+     * Check if MAC address is valid.
+     *
      * @param string $mac Original MAC address.
      * @return bool If MAC address is a valid address.
      */
@@ -64,6 +71,8 @@ final class Mac
 ----------------------------------------------------------------------------- */
 
     /**
+     * Strip characters from MAC address.
+     *
      * @param string $mac Original MAC address.
      * @return string MAC address stripped of separators.
      */
@@ -78,6 +87,8 @@ final class Mac
 ----------------------------------------------------------------------------- */
 
     /**
+     * Convert MAC to plain hex.
+     *
      * @param string $mac Original MAC address.
      * @return string Cleaned MAC address.
      */

--- a/tests/Unit/MacTest.php
+++ b/tests/Unit/MacTest.php
@@ -86,7 +86,7 @@ class MacTest extends TestCase
         $this->assertFalse( $output );
     }
 
-    public function test_isValid_Amost_valid() : void
+    public function test_isValid_Almost_valid() : void
     {
         $output = Mac::isValid( mac: '54:91:AF:B2:02:3G' );
         $this->assertFalse( $output );
@@ -116,6 +116,18 @@ class MacTest extends TestCase
     public function test_isPrivate_E() : void
     {
         $output = Mac::isPrivate( mac: '5E:91:AF:B2:2:3A' );
+        $this->assertTrue( $output );
+    }
+
+    public function test_isPrivate_3() : void
+    {
+        $output = Mac::isPrivate( mac: '53:91:AF:B2:2:3A' );
+        $this->assertTrue( $output );
+    }
+
+    public function test_isPrivate_7() : void
+    {
+        $output = Mac::isPrivate( mac: '57:91:AF:B2:2:3A' );
         $this->assertTrue( $output );
     }
 


### PR DESCRIPTION
Fix isPrivate() to handle locally administered multicast addresses. Suggested by WoBBeLnl.